### PR TITLE
feat: Add component tests for ClerkComponent and improve PricingPlan …

### DIFF
--- a/src/app/_components/global/clerk-component.cy.tsx
+++ b/src/app/_components/global/clerk-component.cy.tsx
@@ -1,0 +1,103 @@
+import ClerkComponent from './clerk-component';
+import { composeStories } from '@storybook/react'; // Assuming Storybook might be used or useful for mocking states
+import * as ClerkNextjs from '@clerk/nextjs';
+
+// Mock Clerk components and hooks
+// A more robust solution might involve a dedicated mock setup for Clerk
+
+// Mock UserButton as it's a simple component for display purposes in this context
+const MockUserButton = () => <div data-cy="user-button">UserButtonMock</div>;
+
+// Mock SignInButton
+const MockSignInButton = ({ children }: { children: React.ReactNode }) => (
+  <div data-cy="sign-in-button">{children}</div>
+);
+
+describe('<ClerkComponent />', () => {
+  beforeEach(() => {
+    // Stub the Clerk hooks and components
+    // For `useUser`
+    cy.stub(ClerkNextjs, 'useUser').as('useUserStub');
+    // For SignedIn and SignedOut, we can mock their behavior by controlling `useUser`
+    // or by directly stubbing them if they are simple enough.
+    // A simple approach for SignedIn/SignedOut is to make them render children based on a mocked auth state.
+
+    // Mock H.identify from highlight-run/next/client
+    // This is called in useEffects and might cause issues if not mocked
+    cy.window().then((win) => {
+      win.H = {
+        identify: cy.stub().as('highlightIdentifyStub'),
+        init: cy.stub().as('highlightInitStub') // if H.init is also used
+      };
+    });
+  });
+
+  context('when user is signed out', () => {
+    beforeEach(() => {
+      // @ts-expect-error - allow stubbing
+      cy.get('@useUserStub').returns({
+        isLoaded: true,
+        isSignedIn: false,
+        user: null,
+      });
+
+      // Mock SignedIn to not render its children and SignedOut to render its children
+      cy.stub(ClerkNextjs, 'SignedIn').callsFake(({ children }) => null); // Does not render children
+      cy.stub(ClerkNextjs, 'SignedOut').callsFake(({ children }) => <>{children}</>); // Renders children
+      cy.stub(ClerkNextjs, 'SignInButton').callsFake(MockSignInButton as any);
+
+
+      cy.mount(<ClerkComponent />);
+    });
+
+    it('should display the Sign In button', () => {
+      cy.get('[data-cy=sign-in-button]').should('be.visible');
+      cy.get('[data-cy=sign-in-button]').should('contain.text', 'Sign In');
+      cy.get('[data-cy=user-button]').should('not.exist');
+    });
+
+    it('should call H.identify for anonymous user on mount', () => {
+      cy.get('@highlightIdentifyStub').should('have.been.calledWithMatch', /^anon=/);
+    });
+  });
+
+  context('when user is signed in', () => {
+    beforeEach(() => {
+      // @ts-expect-error - allow stubbing
+      cy.get('@useUserStub').returns({
+        isLoaded: true,
+        isSignedIn: true,
+        user: {
+          id: 'user_123',
+          firstName: 'Test',
+          lastName: 'User',
+          primaryEmailAddressId: 'email_123',
+          emailAddresses: [{ id: 'email_123', emailAddress: 'test@example.com' }],
+        },
+      });
+
+      // Mock SignedIn to render its children and SignedOut to not render its children
+      cy.stub(ClerkNextjs, 'SignedIn').callsFake(({ children }) => <>{children}</>); // Renders children
+      cy.stub(ClerkNextjs, 'SignedOut').callsFake(({ children }) => null); // Does not render children
+      cy.stub(ClerkNextjs, 'UserButton').callsFake(MockUserButton);
+
+      cy.mount(<ClerkComponent />);
+    });
+
+    it('should display the UserButton', () => {
+      cy.get('[data-cy=user-button]').should('be.visible');
+      cy.get('[data-cy=sign-in-button]').should('not.exist');
+    });
+
+    it('should call H.identify with user details', () => {
+        cy.get('@highlightIdentifyStub').should('have.been.calledWith', 'user_123', {
+        highlightDisplayName: 'Test User',
+        highlightEmail: 'test@example.com',
+        hasUsedFeature: true,
+      });
+    });
+  });
+
+  // TODO: Add tests for Jotai atom updates and tRPC invalidation if possible and sensible in component tests.
+  // This might require more complex mocking of tRPC.
+});

--- a/src/app/_components/plans/pricing-plan.cy.tsx
+++ b/src/app/_components/plans/pricing-plan.cy.tsx
@@ -11,40 +11,47 @@ describe("<PricingPlan />", () => {
       .should("contain.text", "Pricing");
   });
 
-  it("renders exactly two tiers with correct names and prices", () => {
-    cy.get("[data-cy=tier-headers]")
-      .should("have.length", 2)
-      .eq(0)
-      .should("contain.text", "Personal");
+  it("renders tiers with correct names and prices", () => {
+    const expectedTiers = [
+      { name: "Personal", price: "$29" },
+      { name: "Enterprise", price: "$199" },
+    ];
 
-    cy.get("[data-cy=tier-headers]")
-      .should("have.length", 2)
-      .eq(1)
-      .should("contain.text", "Enterprise");
+    cy.get("[data-cy=tier-headers]").should("have.length", expectedTiers.length);
 
-    cy.contains("span", "$29").should("exist");
-    cy.contains("span", "$199").should("exist");
+    expectedTiers.forEach((tier, index) => {
+      cy.get("[data-cy=tier-headers]")
+        .eq(index)
+        .should("contain.text", tier.name)
+        .closest('div') // Move to the parent container of the tier header
+        .parent() // Move to the overall tier card container
+        .find("span.text-5xl") // Find the price span within this tier
+        .should("contain.text", tier.price);
+    });
   });
 
   it("renders the correct number of features for each tier", () => {
+    // Personal tier
     cy.get("[data-cy=tier-lists]")
       .eq(0)
       .find("[data-cy=tier-list-items]")
       .should("have.length", 4);
 
+    // Enterprise tier
     cy.get("[data-cy=tier-lists]")
       .eq(1)
       .find("[data-cy=tier-list-items]")
       .should("have.length", 6);
   });
 
-  it('includes a "Get started today" link for each tier', () => {
+  it('includes a "Get started today" link for each tier with valid href', () => {
     cy.get("[data-cy=purchase-link]")
       .should("have.length", 2)
       .each(($link) => {
         cy.wrap($link)
           .should("be.visible")
           .and("have.attr", "href")
+          .and("not.be.empty")
           .and("match", /^#/);
       });
   });


### PR DESCRIPTION
…tests

Adds new Cypress component tests for ClerkComponent located at `src/app/_components/global/clerk-component.cy.tsx`. These tests cover signed-in and signed-out states by mocking Clerk.js hooks and Highlight.run analytics.

NOTE: The tests for `ClerkComponent` are currently failing. This is due to the `@clerk/nextjs` App Router provider requiring a full Next.js App Router context, which is not available in the default Cypress component testing environment. Resolving this would likely require modifications to the Cypress setup (e.g., Webpack aliasing for `next/navigation`).

Improves existing Cypress component tests for PricingPlan in `src/app/_components/plans/pricing-plan.cy.tsx`:
- Refactored the test for tier names and prices to be more robust by ensuring correct association within each tier's card.
- Enhanced "Get started today" link assertions to also check for non-empty href attributes.
- Updated test descriptions for clarity.

All tests for `PricingPlan` are passing.