### PR TITLE
Add component tests for app components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ yarn-error.log*
 
 # cypress artifacts
 cypress/artifacts
+cypress/downloads
 
 # clerk users test
 clerk_users.json

--- a/src/app/_components/chat/chat-home.cy.tsx
+++ b/src/app/_components/chat/chat-home.cy.tsx
@@ -1,0 +1,42 @@
+import ChatHome from './chat-home';
+import React from 'react';
+import * as NextNav from 'next/navigation';
+import * as AIReact from '@ai-sdk/react';
+import * as TRPC from '~/trpc/react';
+import * as Jotai from 'jotai';
+import * as UpdateProfileModule from '../profile/update-profile';
+import * as Uploadthing from '~/lib/uploadthing';
+
+const MockUpdateProfile = () => <div data-cy="update-profile"></div>;
+const MockUpload = () => <div data-cy="upload"></div>;
+
+describe('<ChatHome />', () => {
+  beforeEach(() => {
+    cy.stub(NextNav, 'useRouter').returns({ replace: cy.stub(), push: cy.stub() } as any);
+    cy.stub(NextNav, 'useParams').returns({ chats: '1' } as any);
+
+    cy.stub(AIReact, 'useChat').returns({
+      messages: [],
+      setMessages: cy.stub(),
+      input: '',
+      handleInputChange: cy.stub(),
+      handleSubmit: cy.stub(),
+      status: 'ready',
+      stop: cy.stub(),
+      reload: cy.stub(),
+    } as any);
+
+    cy.stub(TRPC.api.chat.getChat, 'useQuery').returns({ data: { heartLevel: 2, relationship: 'FRIEND', name: 'Alice' }, isLoading: false, isError: false } as any);
+    cy.stub(TRPC.api.messages.getChatMessages, 'useQuery').returns({ data: [], isLoading: false } as any);
+    cy.stub(TRPC.api.messages.saveMessage, 'useMutation').returns({ mutate: cy.stub() } as any);
+
+    cy.stub(Jotai, 'useAtomValue').returns({ chatData: { heartLevel: 2, relationship: 'FRIEND', name: 'Alice' } } as any);
+    cy.stub(UpdateProfileModule, 'default').callsFake(MockUpdateProfile);
+    cy.stub(Uploadthing, 'UploadDropzone').callsFake(MockUpload);
+  });
+
+  it('displays profile name from data', () => {
+    cy.mount(<ChatHome />);
+    cy.contains('Alice').should('be.visible');
+  });
+});

--- a/src/app/_components/chat/profile-dropdown.cy.tsx
+++ b/src/app/_components/chat/profile-dropdown.cy.tsx
@@ -1,0 +1,18 @@
+import { ProfileDropdown } from './profile-dropdown';
+import React from 'react';
+import * as UpdateProfileModule from '../profile/update-profile';
+
+const MockUpdateProfile = () => <div data-cy="update">Update</div>;
+
+describe('<ProfileDropdown />', () => {
+  beforeEach(() => {
+    cy.stub(UpdateProfileModule, 'default').callsFake(MockUpdateProfile);
+  });
+
+  it('opens menu with update option', () => {
+    cy.mount(<ProfileDropdown />);
+    cy.get('button').click();
+    cy.contains('Settings').should('be.visible');
+    cy.get('[data-cy=update]').should('exist');
+  });
+});

--- a/src/app/_components/global/app-sidebar.cy.tsx
+++ b/src/app/_components/global/app-sidebar.cy.tsx
@@ -1,0 +1,29 @@
+import { AppSidebar } from './app-sidebar';
+import React from 'react';
+import * as Clerk from '@clerk/nextjs';
+import * as TRPC from '~/trpc/react';
+import * as Jotai from 'jotai';
+
+const mockData = [
+  { id: '1', chatData: { chatHeader: 'Chat 1' } },
+];
+
+describe('<AppSidebar />', () => {
+  beforeEach(() => {
+    cy.stub(Clerk, 'useAuth').returns({ isSignedIn: true } as any);
+    cy.stub(TRPC.api.chat.getAllChatHeaders, 'useQuery').returns({ data: mockData, isLoading: false } as any);
+    cy.stub(TRPC.api.chat.deleteChat, 'useMutation').returns({ mutate: cy.stub() } as any);
+    cy.stub(TRPC.api, 'useUtils').returns({ chat: { getAllChatHeaders: { invalidate: cy.stub() } } } as any);
+    cy.stub(Jotai, 'useAtom').returns([mockData, cy.stub()] as any);
+  });
+
+  it('renders chat headers and new chat link', () => {
+    cy.mount(
+      <AppSidebar>
+        <div data-cy="header">X</div>
+      </AppSidebar>
+    );
+    cy.contains('Chat 1').should('exist');
+    cy.contains('New Chat').should('have.attr', 'href', '/create-chat');
+  });
+});

--- a/src/app/_components/global/hero-section.cy.tsx
+++ b/src/app/_components/global/hero-section.cy.tsx
@@ -1,0 +1,25 @@
+import { HeroSection } from './hero-section';
+import React from 'react';
+import * as Dropdown from './model-dropdown';
+import * as Clerk from './clerk-component';
+
+const MockDropdown = () => <div data-cy="dropdown">Dropdown</div>;
+const MockClerk = () => <div data-cy="clerk">Clerk</div>;
+
+describe('<HeroSection />', () => {
+  beforeEach(() => {
+    cy.stub(Dropdown, 'ModelDropdown').callsFake(MockDropdown);
+    cy.stub(Clerk, 'default').callsFake(MockClerk);
+  });
+
+  it('renders children and sub components', () => {
+    cy.mount(
+      <HeroSection state="collapsed">
+        <div data-cy="child">Content</div>
+      </HeroSection>
+    );
+    cy.get('[data-cy=dropdown]').should('exist');
+    cy.get('[data-cy=clerk]').should('exist');
+    cy.get('[data-cy=child]').should('contain.text', 'Content');
+  });
+});

--- a/src/app/_components/global/home.cy.tsx
+++ b/src/app/_components/global/home.cy.tsx
@@ -1,0 +1,31 @@
+import Home from './home';
+import React from 'react';
+import * as Sidebar from '@components/ui/sidebar';
+import * as AppSidebarModule from './app-sidebar';
+import * as Hero from './hero-section';
+
+const MockSidebar = ({ children }: any) => <div data-cy="sidebar">{children}</div>;
+const MockHero = ({ state, children }: any) => (
+  <div data-cy="hero" data-state={state}>
+    {children}
+  </div>
+);
+
+describe('<Home />', () => {
+  beforeEach(() => {
+    cy.stub(Sidebar, 'useSidebar').returns({ state: 'collapsed' } as any);
+    cy.stub(AppSidebarModule, 'AppSidebar').callsFake(MockSidebar);
+    cy.stub(Hero, 'HeroSection').callsFake(MockHero);
+  });
+
+  it('passes sidebar state and renders children', () => {
+    cy.mount(
+      <Home>
+        <div data-cy="child">Test</div>
+      </Home>
+    );
+    cy.get('[data-cy=sidebar]').should('exist');
+    cy.get('[data-cy=hero]').should('have.attr', 'data-state', 'collapsed');
+    cy.get('[data-cy=child]').should('contain.text', 'Test');
+  });
+});

--- a/src/app/_components/global/model-dropdown.cy.tsx
+++ b/src/app/_components/global/model-dropdown.cy.tsx
@@ -1,0 +1,12 @@
+import { ModelDropdown } from './model-dropdown';
+import React from 'react';
+
+describe('<ModelDropdown />', () => {
+  it('shows model options when triggered', () => {
+    cy.mount(<ModelDropdown />);
+    cy.contains('Wally 0.5').click();
+    cy.contains('Models').should('be.visible');
+    cy.contains('Basic').should('be.visible');
+    cy.contains('Premium').should('be.visible');
+  });
+});

--- a/src/app/_components/highlight-boundary.cy.tsx
+++ b/src/app/_components/highlight-boundary.cy.tsx
@@ -1,0 +1,13 @@
+import HighlightErrorBoundary from './highlight-boundary';
+import React from 'react';
+
+describe('<HighlightErrorBoundary />', () => {
+  it('renders children', () => {
+    cy.mount(
+      <HighlightErrorBoundary>
+        <div data-cy="content">Hello</div>
+      </HighlightErrorBoundary>
+    );
+    cy.get('[data-cy=content]').should('contain.text', 'Hello');
+  });
+});

--- a/src/app/_components/jotai-provider.cy.tsx
+++ b/src/app/_components/jotai-provider.cy.tsx
@@ -1,0 +1,29 @@
+import JotaiProvider from './jotai-provider';
+import { atom, useAtom } from 'jotai';
+import * as ClerkNextjs from '@clerk/nextjs';
+import React from 'react';
+
+const counterAtom = atom(0);
+const Counter = () => {
+  const [count, setCount] = useAtom(counterAtom);
+  return (
+    <button data-cy="count" onClick={() => setCount((c) => c + 1)}>
+      {count}
+    </button>
+  );
+};
+
+describe('<JotaiProvider />', () => {
+  beforeEach(() => {
+    cy.stub(ClerkNextjs, 'useUser').returns({ user: { id: '1' } } as any);
+  });
+
+  it('provides jotai store to children', () => {
+    cy.mount(
+      <JotaiProvider>
+        <Counter />
+      </JotaiProvider>
+    );
+    cy.get('[data-cy=count]').should('contain.text', '0').click().should('contain.text', '1');
+  });
+});

--- a/src/app/_components/message/chat-message.cy.tsx
+++ b/src/app/_components/message/chat-message.cy.tsx
@@ -1,0 +1,22 @@
+import { ChatMessage } from './chat-message';
+import React from 'react';
+
+describe('<ChatMessage />', () => {
+  it('renders assistant style by default', () => {
+    cy.mount(
+      <ChatMessage>
+        <span data-cy="text">hello</span>
+      </ChatMessage>
+    );
+    cy.get('div.flex').first().should('have.class', 'flex-row');
+  });
+
+  it('renders user style when isUser', () => {
+    cy.mount(
+      <ChatMessage isUser>
+        <span data-cy="text">hello</span>
+      </ChatMessage>
+    );
+    cy.get('div.flex').first().should('have.class', 'flex-row-reverse');
+  });
+});

--- a/src/app/_components/profile/create-profile.cy.tsx
+++ b/src/app/_components/profile/create-profile.cy.tsx
@@ -1,0 +1,17 @@
+import CreateProfile from './create-profile';
+import React from 'react';
+import * as TRPC from '~/trpc/react';
+import * as NextNav from 'next/navigation';
+
+describe('<CreateProfile />', () => {
+  beforeEach(() => {
+    cy.stub(NextNav, 'useRouter').returns({ push: cy.stub() } as any);
+    cy.stub(TRPC.api.chat.createChat, 'useMutation').returns({ mutate: cy.stub() } as any);
+    cy.stub(TRPC.api, 'useUtils').returns({ chat: { getAllChatHeaders: { invalidate: cy.stub() } } } as any);
+  });
+
+  it('renders profile form', () => {
+    cy.mount(<CreateProfile />);
+    cy.contains('Create Profile').should('exist');
+  });
+});

--- a/src/app/_components/profile/profile-form.cy.tsx
+++ b/src/app/_components/profile/profile-form.cy.tsx
@@ -1,0 +1,31 @@
+import { ProfileForm } from './profile-form';
+import { useForm } from 'react-hook-form';
+import { formSchema } from '../schema';
+import { z } from 'zod';
+import React from 'react';
+
+describe('<ProfileForm />', () => {
+  const Wrapper = () => {
+    const form = useForm<z.infer<typeof formSchema>>({
+      defaultValues: {
+        name: '',
+        gender: '',
+        birthDate: '',
+        relationship: '',
+        heartLevel: 1,
+        race: '',
+        country: '',
+        language: '',
+      },
+    });
+    return (
+      <ProfileForm form={form} handleSubmit={cy.stub()} submitLabel="Submit" />
+    );
+  };
+
+  it('renders form fields', () => {
+    cy.mount(<Wrapper />);
+    cy.get('input[placeholder="Name"]').should('exist');
+    cy.contains('Gender').should('exist');
+  });
+});

--- a/src/app/_components/profile/update-profile.cy.tsx
+++ b/src/app/_components/profile/update-profile.cy.tsx
@@ -1,0 +1,24 @@
+import UpdateProfile from './update-profile';
+import React from 'react';
+import * as NextNav from 'next/navigation';
+import * as TRPC from '~/trpc/react';
+import * as Atoms from '../atoms';
+import * as Jotai from 'jotai';
+
+describe('<UpdateProfile />', () => {
+  beforeEach(() => {
+    cy.stub(NextNav, 'useParams').returns({ chats: '1' } as any);
+    cy.stub(Atoms, 'useMemoChatData').returns(() => null as any);
+    cy.stub(Jotai, 'useAtomValue').returns({
+      chatData: { name: 'Alice', heartLevel: 2, relationship: 'FRIEND' },
+    } as any);
+    cy.stub(TRPC.api.chat.getChat, 'useQuery').returns({ data: null } as any);
+    cy.stub(TRPC.api.chat.updateChat, 'useMutation').returns({ mutate: cy.stub() } as any);
+    cy.stub(TRPC.api, 'useUtils').returns({ chat: { getAllChatHeaders: { invalidate: cy.stub() } } } as any);
+  });
+
+  it('renders dialog trigger', () => {
+    cy.mount(<UpdateProfile />);
+    cy.contains('Edit Profile').should('exist');
+  });
+});


### PR DESCRIPTION
## Summary
- add new Cypress component tests for shared components
- use mocks/stubs to isolate components

## Testing
- `pnpm run component:headless` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6858f02c6e788332ac867404472f123b